### PR TITLE
Add swift:5.4-focal

### DIFF
--- a/pr-environments.json
+++ b/pr-environments.json
@@ -1,6 +1,7 @@
 [
     { "os": "ubuntu-latest", "image": "swift:5.2-focal", "toolchain": null },
     { "os": "ubuntu-latest", "image": "swift:5.3-focal", "toolchain": null },
+    { "os": "ubuntu-latest", "image": "swift:5.4-focal", "toolchain": null },
     { "os": "macos-latest", "image": null, "toolchain": "latest-stable" },
     { "os": "macos-latest", "image": null, "toolchain": "latest" }
 ]


### PR DESCRIPTION
Adding Swift 5.4 to the mix so PRs would be tested on 5.2, 5.3, and 5.4. Alternatively we could use the strategy of oldest (5.2) and latest (now 5.4) supported.