### PR TITLE
Checkout the right repository

### DIFF
--- a/.github/workflows/issues-to-project-board.yml
+++ b/.github/workflows/issues-to-project-board.yml
@@ -16,6 +16,8 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v3.0.1
+        with:
+          repository: 'vapor/ci'
       - name: handle input  
         id: set-matrix
         run: |


### PR DESCRIPTION
add a `with: repository: vapor/ci` to the workflow so it checks out the CI repository