### PR TITLE
Set default params to false for warnings-as-errors

### DIFF
--- a/.github/workflows/run-unit-tests.yml
+++ b/.github/workflows/run-unit-tests.yml
@@ -25,7 +25,7 @@ on:
       warnings_as_errors:
         type: boolean
         required: false
-        default: true
+        default: false
         description: "Set to 'true' to treat warnings as errors. Defaults to 'false'."
       with_api_check:
         type: boolean

--- a/.github/workflows/self-test.yml
+++ b/.github/workflows/self-test.yml
@@ -15,7 +15,7 @@ on:
       warnings_as_errors:
         type: boolean
         required: false
-        default: true
+        default: false
         description: "Set to 'true' to treat warnings as errors. Defaults to 'false'."
       with_api_check:
         type: boolean


### PR DESCRIPTION
When the params were added the defaults were wrongly set to `true`