### PR TITLE
Use Apple's GitHub Workflows linting script

### DIFF
--- a/.github/workflows/run-unit-tests.yml
+++ b/.github/workflows/run-unit-tests.yml
@@ -258,7 +258,9 @@ jobs:
             curl -O https://raw.githubusercontent.com/vapor/contributing/refs/heads/main/.swift-format
           fi
       - name: Lint
-        run: swift-format lint --recursive --strict --parallel .
+        run: |
+          apt -q update && apt -yq install curl
+          curl -s https://raw.githubusercontent.com/swiftlang/github-workflows/refs/heads/main/.github/workflows/scripts/check-swift-format.sh | bash
 
   musl:
     if: ${{ !(github.event.pull_request.draft || false) && inputs.with_musl }}

--- a/.github/workflows/run-unit-tests.yml
+++ b/.github/workflows/run-unit-tests.yml
@@ -258,9 +258,7 @@ jobs:
             curl -O https://raw.githubusercontent.com/vapor/contributing/refs/heads/main/.swift-format
           fi
       - name: Lint
-        run: |
-          apt -q update && apt -yq install curl
-          curl -s https://raw.githubusercontent.com/swiftlang/github-workflows/refs/heads/main/.github/workflows/scripts/check-swift-format.sh | bash
+        run: swift-format lint --recursive --strict --parallel .
 
   musl:
     if: ${{ !(github.event.pull_request.draft || false) && inputs.with_musl }}

--- a/.github/workflows/run-unit-tests.yml
+++ b/.github/workflows/run-unit-tests.yml
@@ -243,8 +243,10 @@ jobs:
     if: ${{ inputs.with_linting }}
     runs-on: ubuntu-latest
     container: swift:6.0-noble
-    timeout-minutes: 30
+    timeout-minutes: 5
     steps:
+      - name: Configure git
+        run: git config --global --add safe.directory "${GITHUB_WORKSPACE}"
       - name: Check out code
         uses: actions/checkout@v4
       - name: Read config file
@@ -256,7 +258,9 @@ jobs:
             curl -O https://raw.githubusercontent.com/vapor/contributing/refs/heads/main/.swift-format
           fi
       - name: Lint
-        run: swift-format lint --recursive --strict --parallel .
+        run: |
+          apt -q update && apt -yq install curl
+          curl -s https://raw.githubusercontent.com/swiftlang/github-workflows/refs/heads/main/.github/workflows/scripts/check-swift-format.sh | bash
 
   musl:
     if: ${{ !(github.event.pull_request.draft || false) && inputs.with_musl }}

--- a/sample-testable-package/Tests/SampleTestablePackageTests/SampleTestablePackageTests.swift
+++ b/sample-testable-package/Tests/SampleTestablePackageTests/SampleTestablePackageTests.swift
@@ -1,5 +1,4 @@
 import XCTest
-
 @testable import SampleTestablePackage
 
 final class SampleTestablePackageTests: XCTestCase {

--- a/sample-testable-package/Tests/SampleTestablePackageTests/SampleTestablePackageTests.swift
+++ b/sample-testable-package/Tests/SampleTestablePackageTests/SampleTestablePackageTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+
 @testable import SampleTestablePackage
 
 final class SampleTestablePackageTests: XCTestCase {


### PR DESCRIPTION
The script is configured to respect a `.swiftformatignore` file which I'll need for Penny.
swift-format might soon have this ability in itself: https://github.com/swiftlang/swift-format/pull/873