### PR TITLE
Add Android workflow

### DIFF
--- a/.github/workflows/run-unit-tests.yml
+++ b/.github/workflows/run-unit-tests.yml
@@ -62,6 +62,11 @@ on:
         required: false
         default: false
         description: "Set to 'true' to build with the Static Linux SDK to test MUSL compatibility. Defaults to 'false'."
+      with_android:
+        type: boolean
+        required: false
+        default: false
+        description: "Set to 'true' to run tests against an Android emulator. Defaults to 'false'."
       ios_scheme_name:
         type: string
         required: false
@@ -274,3 +279,21 @@ jobs:
         run: swift sdk install https://download.swift.org/swift-6.0.2-release/static-sdk/swift-6.0.2-RELEASE/swift-6.0.2-RELEASE_static-linux-0.0.1.artifactbundle.tar.gz --checksum aa5515476a403797223fc2aad4ca0c3bf83995d5427fb297cab1d93c68cee075
       - name: Build
         run: swift build --swift-sdk x86_64-swift-linux-musl ${PACKAGE_PATH} ${EXTRA_FLAGS} ${EXTRA_MUSL_FLAGS} ${WARNINGS_AS_ERRORS}
+
+  android-unit:
+    if: ${{ !(github.event.pull_request.draft || false) && inputs.with_android }}
+    strategy:
+      fail-fast: false
+      matrix:
+        swift-version:
+          - 6.0.3
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+      - name: Run unit tests
+        uses: skiptools/swift-android-action@v2
+        with:
+          swift-version: ${{ matrix.swift-version }}
+

--- a/.github/workflows/self-test.yml
+++ b/.github/workflows/self-test.yml
@@ -42,6 +42,11 @@ on:
         required: false
         default: true
         description: "Set to 'true' to build with the Static Linux SDK to test MUSL compatibility. Defaults to 'true'."
+      with_android:
+        type: boolean
+        required: false
+        default: true
+        description: "Set to 'true' to run tests on Android. Defaults to 'true'."
       ios_scheme_name:
         type: string
         required: false
@@ -65,4 +70,5 @@ jobs:
       with_linting: ${{ inputs.with_linting || true }}
       with_windows: ${{ inputs.with_windows || true }}
       with_musl: ${{ inputs.with_musl || true }}
+      with_android: ${{ inputs.with_android || true }}
       ios_scheme_name: ${{ inputs.ios_scheme_name || 'sample-testable-package-Package' }}


### PR DESCRIPTION
This PR adds the `with_android` input parameter (false by default) to `run-unit-tests.yml` that will use the [swift-android-action](https://github.com/marketplace/actions/swift-android-action) to cross-compile the package for Android and run the tests in an Android emulator.

You can see a successful run of the `self-test.yml` workflow using this new option at: https://github.com/marcprux/ci/actions/runs/12659675167/job/35279261780
