### PR TITLE
Create a runs-on config for the organization

### DIFF
--- a/.github/runs-on.yml
+++ b/.github/runs-on.yml
@@ -1,0 +1,11 @@
+runners:
+  # https://runs-on.com/features/custom-runners/
+  # https://aws.amazon.com/ec2/instance-types/
+  small:
+    cpu: 2
+    ram: 4
+    family: ["c7i", "c7i-flex", "c7a"]
+    hdd: 40
+    image: ubuntu24-full-arm64
+    spot: lowest-price
+    ssh: false


### PR DESCRIPTION
In the repositories we can then use `_extends`: https://runs-on.com/configuration/repo-config/