### PR TITLE
Clearer name for machines

### DIFF
--- a/.github/runs-on.yml
+++ b/.github/runs-on.yml
@@ -1,7 +1,7 @@
 runners:
   # https://runs-on.com/features/custom-runners/
   # https://aws.amazon.com/ec2/instance-types/
-  small:
+  2cpu-4ram:
     cpu: 2
     ram: 4
     family: ["c7i", "c7i-flex", "c7a"]

--- a/.github/runs-on.yml
+++ b/.github/runs-on.yml
@@ -4,7 +4,7 @@ runners:
   2cpu-4ram:
     cpu: 2
     ram: 4
-    family: ["c7i", "c7i-flex", "c7a"]
+    family: ["c7g", "c7gn"]
     hdd: 40
     image: ubuntu24-full-arm64
     spot: lowest-price


### PR DESCRIPTION
I just thought it would be weird to use relative names if we need to add bigger machines in the future.
Like a "2cpu 8ram" machine is still "small", but we already have a machine named "small".

Also change machine types to actual arm machines since the image I've put there is also an arm image.
Arm is cheaper, and it's also nice to have a CI on arm too.