### PR TITLE
Update runs-on machine families

### DIFF
--- a/.github/runs-on.yml
+++ b/.github/runs-on.yml
@@ -4,7 +4,7 @@ runners:
   2cpu-4ram:
     cpu: 2
     ram: 4
-    family: ["c7g", "c7gn"]
+    family: ["c8g", "c7g"]
     hdd: 40
     image: ubuntu24-full-arm64
     spot: lowest-price


### PR DESCRIPTION
looking at [prices](https://aws.amazon.com/ec2/pricing/on-demand/), for hourly on-demand pricing the prices are:

c7gn: $0.1248
c7g: $0.07230
c8g: $0.07948

As you can see c7gn is pricier, and considering our setting of `spot: lowest-price`, it'll most usually just use c7g, currently.
So currently the preference runs-on would have (i'd assume) is: c7g spot, or c7g on-demand, and it will basically never use c7gn.
With this PR, the preference will be: c7g spot, c8g spot, c7g on-demand, and it will likely never use c8g on-demand, but that's still an option. 
