### PR TITLE
feat: Adds opt-in only wasm target to vapor CI workflows

### DIFF
--- a/.github/workflows/run-unit-tests.yml
+++ b/.github/workflows/run-unit-tests.yml
@@ -297,7 +297,7 @@ jobs:
   wasm:
     if: ${{ !(github.event.pull_request.draft || false) && inputs.with_wasm }}
     runs-on: ubuntu-latest
-    container: swift:noble
+    container: swift:6.1.0-noble
     timeout-minutes: 30
     steps:
       - name: Check out code

--- a/.github/workflows/run-unit-tests.yml
+++ b/.github/workflows/run-unit-tests.yml
@@ -305,7 +305,7 @@ jobs:
       # NOTE: Portions of this workflow are adapted from
       # https://github.com/apple/swift-nio/pull/3159/
       - name: Install linux dependencies
-        run: apt-get update -y -q && apt-get install -y -q curl
+        run: apt-get update -y -q && apt-get install -y -q curl && apt-get install -y -q jq
       - name: Install SDK
         run: |
           version="$(swiftc --version | head -n1)"

--- a/.github/workflows/run-unit-tests.yml
+++ b/.github/workflows/run-unit-tests.yml
@@ -57,6 +57,11 @@ on:
         required: false
         default: false
         description: "Set to 'true' to build with the Static Linux SDK to test MUSL compatibility. Defaults to 'false'."
+      with_wasm:
+        type: boolean
+        required: false
+        default: false
+        description: "Set to 'true' to build with the SwiftWasm SDK to test WASM compatibility. Defaults to 'false'."
       with_android:
         type: boolean
         required: false
@@ -288,6 +293,26 @@ jobs:
         run: swift sdk install https://download.swift.org/swift-6.1-release/static-sdk/swift-6.1-RELEASE/swift-6.1-RELEASE_static-linux-0.0.1.artifactbundle.tar.gz --checksum 111c6f7d280a651208b8c74c0521dd99365d785c1976a6e23162f55f65379ac6
       - name: Build
         run: swift build --swift-sdk x86_64-swift-linux-musl ${PACKAGE_PATH} ${EXTRA_FLAGS} ${EXTRA_MUSL_FLAGS} ${WARNINGS_AS_ERRORS}
+        
+  wasm:
+    if: ${{ !(github.event.pull_request.draft || false) && inputs.with_wasm }}
+    runs-on: ubuntu-latest
+    container: swift:noble
+    timeout-minutes: 30
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+      # NOTE: Portions of this workflow are adapted from
+      # https://github.com/apple/swift-nio/pull/3159/
+      - name: Install linux dependencies
+        run: apt-get update -y -q && apt-get install -y -q curl
+      - name: Install SDK
+        run: |
+          version="$(swiftc --version | head -n1)"
+          tag="$(curl -sL "https://raw.githubusercontent.com/swiftwasm/swift-sdk-index/refs/heads/main/v1/tag-by-version.json" | jq -e -r --arg v "$version" '.[$v] | .[-1]')"
+          curl -sL "https://raw.githubusercontent.com/swiftwasm/swift-sdk-index/refs/heads/main/v1/builds/$tag.json" | jq -r '.["swift-sdks"]["wasm32-unknown-wasip1-threads"] | "swift sdk install \"\(.url)\" --checksum \"\(.checksum)\""' | sh -x
+      - name: Build
+        run: swift build --swift-sdk wasm32-unknown-wasip1-threads ${PACKAGE_PATH} ${EXTRA_FLAGS} ${WARNINGS_AS_ERRORS}
 
   android-unit:
     if: ${{ !(github.event.pull_request.draft || false) && inputs.with_android }}

--- a/.github/workflows/self-test.yml
+++ b/.github/workflows/self-test.yml
@@ -32,26 +32,17 @@ on:
         required: false
         default: true
         description: "Set to 'true' to run swift-format's lint process. Defaults to 'true'."
-      with_windows:
-        type: boolean
+      with_platform:
+        type: choice
+        options:
+          - all
+          - windows
+          - musl
+          - wasm
+          - android
         required: false
-        default: true
-        description: "Set to 'true' to run tests on Windows. Defaults to 'true'."
-      with_musl:
-        type: boolean
-        required: false
-        default: true
-        description: "Set to 'true' to build with the Static Linux SDK to test MUSL compatibility. Defaults to 'true'."
-      with_wasm:
-        type: boolean
-        required: false
-        default: true
-        description: "Set to 'true' to build with the Wasm SDK to test Wasm compatibility. Defaults to 'true'."
-      with_android:
-        type: boolean
-        required: false
-        default: true
-        description: "Set to 'true' to run tests on Android. Defaults to 'true'."
+        default: all
+        description: "Select which platform to test, or select 'all' to test all platforms"
       ios_scheme_name:
         type: string
         required: false
@@ -73,8 +64,8 @@ jobs:
       with_api_check: ${{ inputs.with_api_check || true }}
       warnings_as_errors: ${{ inputs.warnings_as_errors || true }}
       with_linting: ${{ inputs.with_linting || true }}
-      with_windows: ${{ inputs.with_windows || true }}
-      with_musl: ${{ inputs.with_musl || true }}
-      with_wasm: ${{ inputs.with_wasm || true }}
-      with_android: ${{ inputs.with_android || true }}
+      with_windows: ${{ inputs.with_platform == 'all' || inputs.with_platform == 'windows' || true }}
+      with_musl: ${{ inputs.with_platform == 'all' || inputs.with_platform == 'musl' || true }}
+      with_wasm: ${{ inputs.with_platform == 'all' || inputs.with_platform == 'wasm' || true }}
+      with_android: ${{ inputs.with_platform == 'all' || inputs.with_platform == 'android'|| true }}
       ios_scheme_name: ${{ inputs.ios_scheme_name || 'sample-testable-package-Package' }}

--- a/.github/workflows/self-test.yml
+++ b/.github/workflows/self-test.yml
@@ -42,6 +42,11 @@ on:
         required: false
         default: true
         description: "Set to 'true' to build with the Static Linux SDK to test MUSL compatibility. Defaults to 'true'."
+      with_wasm:
+        type: boolean
+        required: false
+        default: true
+        description: "Set to 'true' to build with the Wasm SDK to test Wasm compatibility. Defaults to 'true'."
       with_android:
         type: boolean
         required: false
@@ -70,5 +75,6 @@ jobs:
       with_linting: ${{ inputs.with_linting || true }}
       with_windows: ${{ inputs.with_windows || true }}
       with_musl: ${{ inputs.with_musl || true }}
+      with_wasm: ${{ inputs.with_wasm || true }}
       with_android: ${{ inputs.with_android || true }}
       ios_scheme_name: ${{ inputs.ios_scheme_name || 'sample-testable-package-Package' }}


### PR DESCRIPTION
# Change summary

Added swift wasm as an opt-in only CI target, to help prevent future breakages to swift wasm builds in vapor repositories.

New usage of the wasm build will be added to vapor repositories on a case-by-case basis, once the required wasm support is in place.

# Notes

This PR is [part of a larger effort](https://github.com/PassiveLogic/swift-web-examples/issues/1) by PassiveLogic to add wasm support to many popular repositories.

# Testing done

Verified this new workflow functions correctly using a temporary PR that enables the new wasm build.

See https://github.com/PassiveLogic/sql-kit/actions/runs/15886122859/job/44798410586?pr=1