### PR TITLE
Update benchmark RunsOn config

### DIFF
--- a/.github/workflows/run-benchmark.yml
+++ b/.github/workflows/run-benchmark.yml
@@ -17,12 +17,7 @@ env:
 jobs:
   benchmark-vs-thresholds:
     # https://runs-on.com/features/custom-runners/
-    runs-on:
-      labels:
-        - runs-on
-        - runner=2cpu-4ram
-        - run-id=${{ github.run_id }}
-
+    runs-on: runs-on=${{ github.run_id }}/cpu=2/ram=4
     container: swift:noble
 
     defaults:


### PR DESCRIPTION
Apparently the RunsOn syntax for custom runners changed https://runs-on.com/runners/linux/. According https://runs-on.com/configuration/job-labels/#how-it-works, the current state of the PR should simply update the syntax and keep the old runner config. We could also take this opportunity to update the runner to be ARM or one of the default runners