### PR TITLE
Add Swift 6.3 nightlies to CI

### DIFF
--- a/.github/workflows/run-unit-tests.yml
+++ b/.github/workflows/run-unit-tests.yml
@@ -140,6 +140,8 @@ jobs:
           - { image: "swift:6.1-noble", "build-mode": "debug" }
           - { image: "swift:6.2-noble", "build-mode": "debug" }
           - { image: "swift:6.2-noble", "build-mode": "release" }
+          - { image: "swiftlang/swift:nightly-6.3-noble", "build-mode": "debug" }
+          - { image: "swiftlang/swift:nightly-6.3-noble", "build-mode": "release" }
     runs-on: ubuntu-latest
     container: ${{ matrix.swift-config.image }}
     timeout-minutes: 60


### PR DESCRIPTION
Swift 6.3 should be released in 1.5/2 months. Let's add a CI for checking against 6.3 nightlies so we can report back any potential issues and ensure Vapor packages build fine in 6.3 as well.