### PR TITLE
Remove swift nightly main CI for now

### DIFF
--- a/.github/workflows/run-unit-tests.yml
+++ b/.github/workflows/run-unit-tests.yml
@@ -176,8 +176,7 @@ jobs:
               (if $sm2 == "1" then                   [{ image: "swift:6.1-noble", "build-mode": "debug" }] else [] end) +
               (if $sm1 == "1" then                   [{ image: "swift:6.2-noble", "build-mode": "debug" }] else [] end) +
               (if $scr == "1" then                   [{ image: "swift:6.3-noble", "build-mode": "debug" }] else [] end) +
-              (if $scr == "1" and $rltst == "1" then [{ image: "swift:6.3-noble", "build-mode": "release" }] else [] end) +
-                                                     [{ image: "swiftlang/swift:nightly-main-noble", "build-mode": "debug" }]
+              (if $scr == "1" and $rltst == "1" then [{ image: "swift:6.3-noble", "build-mode": "release" }] else [] end)
             )}')" >> "${GITHUB_OUTPUT}"
     
   linux-unit:

--- a/.github/workflows/run-unit-tests.yml
+++ b/.github/workflows/run-unit-tests.yml
@@ -177,6 +177,7 @@ jobs:
               (if $sm1 == "1" then                   [{ image: "swift:6.2-noble", "build-mode": "debug" }] else [] end) +
               (if $scr == "1" then                   [{ image: "swift:6.3-noble", "build-mode": "debug" }] else [] end) +
               (if $scr == "1" and $rltst == "1" then [{ image: "swift:6.3-noble", "build-mode": "release" }] else [] end)
+                                                  #+ [{ image: "swiftlang/swift:nightly-main-noble", "build-mode": "debug" }]
             )}')" >> "${GITHUB_OUTPUT}"
     
   linux-unit:


### PR DESCRIPTION
Like with what we did with 6.3, remove Linux nightly CI to ensure it doesn't make the README CI labels go red [like in Penny](https://github.com/vapor/penny-bot).

We'll add 6.4 nightly CI when we're closer (2-3 months) to a 6.4 release to catch any possible issues.
